### PR TITLE
support.v4 24+ に依存するとクラッシュする不具合の修正

### DIFF
--- a/ncmb.gradle
+++ b/ncmb.gradle
@@ -1,0 +1,5 @@
+configurations.all {
+    resolutionStrategy {
+        force 'com.android.support:support-v4:23.4.0'
+    }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -62,6 +62,7 @@
             <meta-data android:name="openPushStartActivity" android:value=".MainActivity"/>
             <meta-data android:name="notificationOverlap" android:value="1"/>
         </config-file>
+        <framework src="ncmb.gradle" custom="true" type="gradleReference"/>
         <framework src="com.google.android.gms:play-services-gcm:8.1.0" />
         <framework src="com.google.code.gson:gson:2.4" />
         <lib-file src="src/android/libs/NCMB.jar" />


### PR DESCRIPTION
## 概要(Summary)

support.v4 24+ に依存するとクラッシュする不具合の修正
(#10 の問題と同様と想定される)
## 動作確認手順(Step for Confirmation)
1. cordovaでプロジェクトを新規作成
2. cordova-plugin-crosswalk-webview 1.7.0とncmb-monaca-push-pluginをプラグイン追加
3. ncmb-monaca-push-pluginのプッシュ通知設定API呼び出しのコードを追加
4. ビルド (cordova build android)
5. 実行 (cordova run android)
6. プッシュ通知設定API呼び出し部分でクラッシュ
## 原因

下記と同様の現象が発生していると想定されます。
https://github.com/phonegap/phonegap-plugin-push/issues/909

本プルリクでは下記と同様の対策を施しました。
https://github.com/phonegap/phonegap-plugin-push/issues/909#issuecomment-220923606

本件はcordova-plugin-crosswalk-webviewプラグイン追加に限らず、support.v4 24+への依存が発生すると再現する模様です。

cordova-plugin-crosswalk-webviewを利用するケースだと、コアライブラリ内のmaven/pomレベルでsupport.v4 +への依存が指定されており、最新のSDKでビルドすると自動的にsupport.v4 24+に依存します。単純にplugin.xmlでのsupport.v4 バージョンを指定する方法では解決できなかったため、上記リンクと同様に、gradleレベルで強制する方法を採用しています。
