### PR TITLE
setHandler is fired when JSON data is empty on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ncmb-push-monaca-plugin",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Nifty Cloud mobile backend Push Notification Plugin for Monaca",
   "author": "",
   "license": "Apache License 2.0",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,23 +2,23 @@
 <!--
   NiftyMB Cloud for Push Notificaction Plugin
   Copyright 2016 NIFTY Corporation. All Rights Reserved.
-  
+
   GooglePlayServices library
   Copyright (c) 2013 The Chromium Authors. All rights reserved.
 -->
 <plugin
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="plugin.push.nifty"
-    version="2.0.2">
+    version="2.0.3">
 
     <name>NiftyMB</name>
     <description>NiftyMB Cloud for Push Notification Plugin</description>
     <license>Copyright 2014 NIFTY Corporation. All Rights Reserved.</license>
-    
+
     <engines>
         <engine name="cordova" version=">=3.0.0" />
     </engines>
-    
+
     <js-module src="www/nifty.js" name="NiftyCloud">
         <clobbers target="NCMB.monaca" />
         <runs/>
@@ -187,4 +187,3 @@
         <framework src="CoreLocation.framework" />
     </platform>
 </plugin>
-

--- a/src/android/NiftyPushPlugin.java
+++ b/src/android/NiftyPushPlugin.java
@@ -138,11 +138,15 @@ public class NiftyPushPlugin extends CordovaPlugin
             return;
         }
 
+        JSONObject json = null;
         if (data.hasJson()) {
-            PluginResult result = new PluginResult(PluginResult.Status.OK, new JSONObject(data.getJson()));
-            result.setKeepCallback(true);
-            mPushReceivedCallbackContext.sendPluginResult(result);
+            json = new JSONObject(data.getJson());
+        } else {
+            json = new JSONObject();
         }
+        PluginResult result = new PluginResult(PluginResult.Status.OK, json);
+        result.setKeepCallback(true);
+        mPushReceivedCallbackContext.sendPluginResult(result);
 
         // Use dummy intent to call trackAppOpened and richPushHandler.
         Intent dummyIntent = data.createIntent();


### PR DESCRIPTION
SDKの改善にご協力いただきありがとうございます。  
(Thank you for your support our SDK.)

プルリクエストを作成する場合は、developをターゲットにしてください。  
(Please select target branch to "develop" branch.)

可能な限り、修正時にはテストコードまたは動作確認手順を追加してください。  
(Please include test code or describe confirmation steps as possible.)

## 概要(Summary)

Androidのみ、プッシュ通知時のJSONデータがないと、setHandlerが発火しない
不具合を修正。
(iOSでは、JSONデータがない場合でもsetHandlerが発火する。こちらが正しい仕様)

これにともない、アプリバージョンを2.0.2から2.0.3に変更（plugin.xmlのidと、package.json
のversionのどちらも変更済み）
npmリポジトリへの反映もお願いします。


- Fixed #xx

## 動作確認手順(Step for Confirmation)

setHandlerを組み込んだアプリを作成。
mBaaSから、JSONデータなしでPush通知を送る。
setHandlerが発火すればOK

            document.addEventListener("deviceready",onDeviceReady,false);
            function onDeviceReady() {
                window.NCMB.monaca.setDeviceToken("ae83a74c698af5bc59ad0dad8fbef5d6d2d7657f9bf6c59086b37905b0e67ecd",
                    "f0db8a2d9f293c539eea11760efaaf54bbd1ed22660a8d461a892c059d9dd0f6",
                    "699814914739"
                );
                window.NCMB.monaca.setHandler(
                    function(data) { alert( JSON.stringify(data) ); }
                );

            }

Run the unit test.
