### PR TITLE
support.v4 24+ に依存するとクラッシュする不具合の修正のMonaca Cordova 5.2対応

### DIFF
--- a/ncmb.gradle
+++ b/ncmb.gradle
@@ -1,0 +1,5 @@
+configurations.all {
+    resolutionStrategy {
+        force 'com.android.support:support-v4:23.4.0'
+    }
+}

--- a/ncmb.gradle
+++ b/ncmb.gradle
@@ -1,5 +1,5 @@
 configurations.all {
     resolutionStrategy {
-        force 'com.android.support:support-v4:23.4.0'
+        force 'com.android.support:support-v4:22.2.1'
     }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -62,6 +62,7 @@
             <meta-data android:name="openPushStartActivity" android:value=".MainActivity"/>
             <meta-data android:name="notificationOverlap" android:value="1"/>
         </config-file>
+        <framework src="ncmb.gradle" custom="true" type="gradleReference"/>
         <framework src="com.google.android.gms:play-services-gcm:8.1.0" />
         <framework src="com.google.code.gson:gson:2.4" />
         <lib-file src="src/android/libs/NCMB.jar" />


### PR DESCRIPTION
## 概要(Summary)

- Related #12

support.v4 24+ に依存するとクラッシュする不具合の修正で support.v4 23.4 の使用を強制するよう変更されたが、MonacaのCordova 5.2 ビルド環境ではAndroid SDKのバージョンが22固定のため support.v4 23.4 が使用できない問題が発生する。

本プラグインの動作環境(Cordova 5.2 ~)維持のため、使用を強制するサポートライブラリのバージョンを support.v4 22.2.1 に変更します。

## 動作確認手順(Step for Confirmation)

全部で6パターンあります。 (Cordova 5.2/6.2 × ncmb-monaca-push-plugin master/develop/#18)

1. Monacaでプロジェクトを新規作成 (Cordova 5.2 および 6.2の両方で試験)
1. cordova-plugin-crosswalk-webview をプラグイン追加
    - Cordova 5.2の場合はデフォルトのバージョン (そもそも1.7.0がcordova5.2に対応していない)
    - Cordova 6.2では1.7.0以上
1. ncmb-monaca-push-pluginをプラグイン追加
    - master (リリース版)
    - develop ( #12 適用版)
    - #18 (本P-R)
1. cordova-plugin-crosswalk-webview のアーキテクチャを適切に設定 
    - 実機の場合はほぼarm、エミュレータはx86/armのいずれか仮想端末作成時に選択したもの
1. ncmb-monaca-push-pluginのプッシュ通知設定API呼び出しのコードを追加
1. ビルド
    - 現在の開発版 (develop) では、cordova 5.2 環境の場合にここでビルドに失敗する
1. 実行
1. プッシュ通知設定API呼び出し部分でクラッシュしないことを確認
    - 現在のリリース版(master) ではここでクラッシュする
    - #18 ではビルドも通り、アプリもクラッシュしない