### PR TITLE
installation 再登録時の「E404001: No data available」対応

### DIFF
--- a/src/ios/NiftyPushNotification.m
+++ b/src/ios/NiftyPushNotification.m
@@ -260,6 +260,8 @@ static BOOL hasSetup = NO;
         } else {
             if (error.code == 409001) {
                 [self updateExistInstallation:installation];
+            } else if (error.code == 404001){
+                [self reRegistInstallation:deviceToken];
             } else {
                 [self callSetDeviceTokenErrorOnUiThreadWith: error.code message:kNiftyPushErrorMessageFailedToSave];
             }
@@ -288,6 +290,21 @@ static BOOL hasSetup = NO;
         }
     } ];
 
+}
+
+/**
+ * When No data available, create a new installation.
+ */
+-(void)reRegistInstallation:(NSData*)deviceToken{
+    NCMBInstallation *newInstallation = [[NCMBInstallation alloc]init];
+    [newInstallation setDeviceTokenFromData:deviceToken];
+    [newInstallation saveInBackgroundWithBlock:^(NSError *error) {
+        if(!error){
+            [self callSetDeviceTokenSuccessOnUiThread];
+        } else {
+            [self callSetDeviceTokenErrorOnUiThreadWith:error.code message:kNiftyPushErrorMessageFailedToSave];
+        }
+    }];
 }
 
 #pragma mark - Get InstalationId


### PR DESCRIPTION
## 概要(Summary)
コンパネ上等でinstallationが削除された場合のE404001エラー時にinstallationを再登録するように修正。

- Fixed #25

## 動作確認手順(Step for Confirmation)

アプリをインストール
インスタレーションを登録 -> コンパネ上で削除
再びアプリを起動（バックグラウンドからの復帰ではなく）
mBaaSに再度インスタレーションが登録されているか確認