### PR TITLE
Dev fix error key value inversion

### DIFF
--- a/src/ios/NiftyPushNotification.m
+++ b/src/ios/NiftyPushNotification.m
@@ -197,8 +197,8 @@ static BOOL hasSetup = NO;
 
 - (void)callSetDeviceTokenErrorOnUiThread:(NSString*)code message:(NSString*)message {
     NSDictionary *json = [NSDictionary dictionaryWithObjectsAndKeys:
-                          code, @"code",
-                          message, @"message", 
+                          @"code", code,
+                          @"message", message,
                           nil];
     [self performSelectorOnMainThread:@selector(callSetDeviceTokenError:) withObject:json waitUntilDone:NO];
 }
@@ -244,15 +244,22 @@ static BOOL hasSetup = NO;
     hasSetup = YES;
 
     if (deviceToken != nil) {
-        [self performSelectorInBackground:@selector(saveInBackgroundWithBlock:) withObject:deviceToken];
+        [self performSelectorInBackground:@selector(saveInBackgroundWithBlockFirst:) withObject:deviceToken];
     }
+}
+
+- (void)saveInBackgroundWithBlockFirst:(NSData*)deviceToken {
+    [self saveInBackgroundWithBlock:deviceToken withInstallation:nil];
 }
 
 /**
  * Save device token in nifty mBaas.
  */
-- (void)saveInBackgroundWithBlock:(NSData*)deviceToken {
-    NCMBInstallation *installation = [NCMBInstallation currentInstallation];
+- (void)saveInBackgroundWithBlock:(NSData*)deviceToken withInstallation:(NCMBInstallation *) inst {
+    NCMBInstallation *installation = inst;
+    if (installation == nil) {
+        installation = [NCMBInstallation currentInstallation];
+    }
     [installation setDeviceTokenFromData:deviceToken];
     [installation saveInBackgroundWithBlock:^(NSError *error) {
         if (!error) {
@@ -260,6 +267,9 @@ static BOOL hasSetup = NO;
         } else {
             if (error.code == 409001) {
                 [self updateExistInstallation:installation];
+            } else if (error.code == 404001 && inst == nil) {
+                installation.objectId = nil;
+                [self saveInBackgroundWithBlock:deviceToken withInstallation:installation];
             } else {
                 [self callSetDeviceTokenErrorOnUiThreadWith: error.code message:kNiftyPushErrorMessageFailedToSave];
             }

--- a/src/ios/NiftyPushNotification.m
+++ b/src/ios/NiftyPushNotification.m
@@ -197,8 +197,8 @@ static BOOL hasSetup = NO;
 
 - (void)callSetDeviceTokenErrorOnUiThread:(NSString*)code message:(NSString*)message {
     NSDictionary *json = [NSDictionary dictionaryWithObjectsAndKeys:
-                          @"code", code,
-                          @"message", message,
+                          code, @"code",
+                          message, @"message",
                           nil];
     [self performSelectorOnMainThread:@selector(callSetDeviceTokenError:) withObject:json waitUntilDone:NO];
 }

--- a/src/ios/NiftyPushNotification.m
+++ b/src/ios/NiftyPushNotification.m
@@ -64,11 +64,11 @@ static BOOL hasSetup = NO;
 + (void) setupNCMB {
     NSString *appKey = [[self class] getAppKey];
     NSString *clientKey = [[self class] getClientKey];
-    
+
     if (appKey == nil || clientKey == nil) {
         return;
     }
-    
+
     [NCMB setApplicationKey:appKey clientKey:clientKey];
     hasSetup = YES;
 }
@@ -80,7 +80,7 @@ static BOOL hasSetup = NO;
     if (!hasSetup) {
         return;
     }
-    
+
     if ([NiftyPushNotification isReceiptStatusOk]) {
         [NCMBAnalytics trackAppOpenedWithLaunchOptions:launchOptions];
     }
@@ -93,7 +93,7 @@ static BOOL hasSetup = NO;
     if (!hasSetup) {
         return;
     }
-    
+
     if ([NiftyPushNotification isReceiptStatusOk]) {
         [NCMBAnalytics trackAppOpenedWithRemoteNotificationPayload:userInfo];
     }
@@ -106,7 +106,7 @@ static BOOL hasSetup = NO;
     if (!hasSetup) {
         return;
     }
-    
+
     [NCMBPush handleRichPush:userInfo];
 }
 
@@ -144,19 +144,19 @@ static BOOL hasSetup = NO;
  */
 - (void) setDeviceToken:(CDVInvokedUrlCommand*)command {
     _setDeviceTokenCallbackId = command.callbackId;
-    
+
     if (![self validateInputParameters:command.arguments]) {
         [self callSetDeviceTokenErrorOnUiThread:kNiftyPushErrorCodeInvalidParams message: kNiftyPushErrorMessageInvalidParams];
         return;
     }
-    
+
     NSString* appKey    = [command.arguments objectAtIndex:0];
     NSString* clientKey = [command.arguments objectAtIndex:1];
     [[NSUserDefaults standardUserDefaults] setObject:appKey forKey:kNiftyPushAppKey];
     [[NSUserDefaults standardUserDefaults] setObject:clientKey forKey:kNiftyPushClientKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
     [self installWithAppKey:appKey clientKey:clientKey deviceToken:[[self class] getDeviceTokenAPNS]];
-    
+
     if (_isFailedToRegisterAPNS) {
         _isFailedToRegisterAPNS = NO;
         [self callSetDeviceTokenErrorOnUiThread:kNiftyPushErrorCodeFailedToRegisterAPNS message: kNiftyPushErrorMessageFailedToRegisterAPNS];
@@ -197,8 +197,8 @@ static BOOL hasSetup = NO;
 
 - (void)callSetDeviceTokenErrorOnUiThread:(NSString*)code message:(NSString*)message {
     NSDictionary *json = [NSDictionary dictionaryWithObjectsAndKeys:
-                          @"code", code,
-                          @"message", message,
+                          code, @"code",
+                          message, @"message", 
                           nil];
     [self performSelectorOnMainThread:@selector(callSetDeviceTokenError:) withObject:json waitUntilDone:NO];
 }
@@ -239,10 +239,10 @@ static BOOL hasSetup = NO;
     if (appKey == nil || clientKey == nil) {
         return;
     }
-    
+
     [NCMB setApplicationKey:appKey clientKey:clientKey];
     hasSetup = YES;
-    
+
     if (deviceToken != nil) {
         [self performSelectorInBackground:@selector(saveInBackgroundWithBlock:) withObject:deviceToken];
     }
@@ -342,7 +342,7 @@ static BOOL hasSetup = NO;
     if (_pushReceivedCallbackId != nil && _webViewLoadFinished) {
         while (![_queue isEmpty]) {
             NSDictionary *json = [_queue dequeue];
-            
+
             if (json != nil) {
                 [self sendJson:json callbackId:_pushReceivedCallbackId];
             }


### PR DESCRIPTION
SDKの改善にご協力いただきありがとうございます。  
(Thank you for your support our SDK.)

プルリクエストを作成する場合は、developをターゲットにしてください。  
(Please select target branch to "develop" branch.)

可能な限り、修正時にはテストコードまたは動作確認手順を追加してください。  
(Please include test code or describe confirmation steps as possible.)

## 概要(Summary)

修正は、iOS版のみ。
src/ios/NiftyPushNotification.mファイルのみが修正されています。

1. setDeviceToken時にエラーが発生した場合に取得されるjsonが、キーとバリューが逆に
なっていたため、修正。

2. setDeviceToken後、サーバー側でinstallationを削除してしまうと、以後、アプリ側で
setDeviceTokenを実行してもエラーとなってしまいます。
この状態になると、アプリを削除しない限り二度とdeviceTokenを登録出来ない問題がありました。
この問題を改善しました。(404001エラー対応）

なお、config.xmlやpackage.json内のバージョンコードは変えていないので、本番反映時に
は適時変更をお願いします。

- Fixed #xx

## 動作確認手順(Step for Confirmation)

1. setDeviceToken時にエラーを発生させる。（例えば、Push通知を許可していない
プロビジョニングファイルを使ってビルドするなどすると、エラーが発生します）
これまでのバージョンでは、
window.NCMB.monaca.setDeviceTokenの第五引数に指定したエラー時の関数の引数
すなわち
window.NCMB.monaca.setDeviceToken(
  'app-key', 'client-key' , 'sender-id' ,
  function (json1) { /* success case */ } ,
  function (json2) { /* fail case */ }
)
で呼び出したときのjson2の内容が、
{ 
 'エラーコード番号' : code,
 'エラーメッセージ' : message 
}
となっていました。これが正しく
{ 
 code : 'エラーコード番号',
 message:'エラーメッセージ'
}
となります。


2. setDeviceToken実行後、サーバー側のデータストアのinstallationのところに記録された
データを、手動で消してみます。

　すると、今までのバージョンでは、アプリを一度削除しない限り、再登録ができませんでした。

　新しいバージョンでは、404001エラーが発生した場合、installation.objectId=nilとして、
再度、installation saveInBackgroundWithBlockメソッドを試みます。その結果、アプリを
削除しなくても、再登録を行うことができます。

Run the unit test.
