### PR TITLE
Do not call Push receiving event and show dialog when app foreground on ios 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## Specifications
 
- - PhoneGap/Cordova 5.2 ~
- - iOS/Android
-   - Support OS version: See Nifty Cloud mobile backend [iOS SDK](https://github.com/NIFTYCloud-mbaas/ncmb_ios), [Android SDK](https://github.com/NIFTYCloud-mbaas/ncmb_android) Specifications.
-   - In case of Cordova 6.5, support iOS version 9.0 ~
+ - PhoneGap/Cordova 6.5 ~
+ - iOS/Android Support OS version:
+    - iOS: 9.x ~
+    - Android: see [Android SDK](https://github.com/NIFTYCloud-mbaas/ncmb_android) Specifications.
 ---
 
 ## Methods

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Nifty Cloud Mobile Backend Push Notification Plugin for Monaca
+# Nifty Cloud Mobile Backend Push Notification Plugin for Monaca
 
 ---
 
@@ -7,12 +7,12 @@
  - PhoneGap/Cordova 5.2 ~
  - iOS/Android
    - Support OS version: See Nifty Cloud mobile backend [iOS SDK](https://github.com/NIFTYCloud-mbaas/ncmb_ios), [Android SDK](https://github.com/NIFTYCloud-mbaas/ncmb_android) Specifications.
-
+   - In case of Cordova 6.5, support iOS version 9.0 ~
 ---
 
 ## Methods
 
-###window.NCMB.monaca.setDeviceToken(applicationKey,clientKey,senderId, successCallback, errorCallback)
+### window.NCMB.monaca.setDeviceToken(applicationKey,clientKey,senderId, successCallback, errorCallback)
 
 Register device-token to Nifty cloud mobile backend datastore (Installation class).
 
@@ -22,19 +22,19 @@ Register device-token to Nifty cloud mobile backend datastore (Installation clas
  - (Function)successCallback() (OPTIONAL)
  - (Function)errorCallback(error) (OPTIONAL)
 
-###window.NCMB.monaca.setHandler(callback)
+### window.NCMB.monaca.setHandler(callback)
 
 Set the callback when app receive a push notification.
 
 - (function)callback(jsonData)
 
-###window.NCMB.monaca.getInstallationId(callback)
+### window.NCMB.monaca.getInstallationId(callback)
 
 Get the Installation objectId for device.
 
 - (function)callback(installationId)
 
-###window.NCMB.monaca.setReceiptStatus(flag, callback);
+### window.NCMB.monaca.setReceiptStatus(flag, callback);
 
 Set the notification open receipt status to be store or not.
 This status will be used to create Push notification open status statistic graph.
@@ -44,7 +44,7 @@ This status will be used to create Push notification open status statistic graph
     - false : No send
 - (Function) callback() (OPTIONAL)
 
-###window.NCMB.monaca.getReceiptStatus(callback);
+### window.NCMB.monaca.getReceiptStatus(callback);
 
 Get the notification open receipt status.
 
@@ -53,6 +53,7 @@ Get the notification open receipt status.
 ---
 
 ## Sample
+
 ```
     <!DOCTYPE HTML>
     <html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ncmb-push-monaca-plugin",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Nifty Cloud mobile backend Push Notification Plugin for Monaca",
   "author": "",
   "license": "Apache License 2.0",

--- a/plugin.xml
+++ b/plugin.xml
@@ -78,6 +78,12 @@
                 <param name="onload" value="true"/>
             </feature>
         </config-file>
+        <config-file target="*-Debug.plist" parent="aps-environment">
+          <string>development</string>
+        </config-file>
+        <config-file target="*-Release.plist" parent="aps-environment">
+          <string>production</string>
+        </config-file>
         <header-file src="src/ios/AppDelegate+NiftyCloud.h" />
         <source-file src="src/ios/AppDelegate+NiftyCloud.m" />
         <header-file src="src/ios/NiftyPushNotification.h" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  NiftyMB Cloud for Push Notificaction Plugin
+  Nifty Cloud Mobile Backend Push Notification Plugin
   Copyright 2017 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
   GooglePlayServices library
@@ -9,10 +9,10 @@
 <plugin
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="plugin.push.nifty"
-    version="2.0.6">
+    version="2.0.7">
 
     <name>NiftyMB</name>
-    <description>NiftyMB Cloud for Push Notification Plugin</description>
+    <description>Nifty Cloud Mobile Backend Push Notification Plugin</description>
     <license>Copyright 2017 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.</license>
 
     <engines>

--- a/plugin.xml
+++ b/plugin.xml
@@ -160,5 +160,6 @@
         <framework src="AudioToolbox.framework" />
         <framework src="SystemConfiguration.framework" />
         <framework src="CoreLocation.framework" />
+        <framework src="UserNotifications.framework" />
     </platform>
 </plugin>

--- a/src/ios/AppDelegate+NiftyCloud.h
+++ b/src/ios/AppDelegate+NiftyCloud.h
@@ -5,7 +5,8 @@
 
 
 #import "AppDelegate.h"
+#import <UserNotifications/UserNotifications.h>
 
-@interface AppDelegate (NiftyCloud)
+@interface AppDelegate (NiftyCloud) <UNUserNotificationCenterDelegate>
 
 @end


### PR DESCRIPTION
## 概要(Summary)

- Fixed #133826
アプリ起動中にプッシュ通知を受信した時にイベントを走らせない、プッシュ通知ダイアログを表示する。
## 動作確認手順(Step for Confirmation)
iOS10端末のアプリを起動中状態でプッシュ通知を送信すると「プッシュ通知受信時のコールバック」を走らせなくてプッシュ通知ダイアログを表示することを確認

## Note
+ Cordova 6.2系では動作しません。