### PR TITLE
Fix #42 installation.delete()しても次回アプリ起動時に自動的に再登録されてしまう

### DIFF
--- a/src/ios/NiftyPushNotification.m
+++ b/src/ios/NiftyPushNotification.m
@@ -267,7 +267,7 @@ static BOOL hasSetup = NO;
         } else {
             if (error.code == 409001) {
                 [self updateExistInstallation:installation];
-            } else if (error.code == 404001 && inst == nil) {
+            } else if (error.code == 404001 && inst == nil && _setDeviceTokenCallbackId) {
                 installation.objectId = nil;
                 [self saveInBackgroundWithBlock:deviceToken withInstallation:installation];
             } else {


### PR DESCRIPTION
## 概要(Summary)

- Fixed #42

## 動作確認手順(Step for Confirmation)

・setDeviceTokenしてNCMBのinstallationに登録する
・コンパネでinstallationを削除する
・アプリを再起動する => 登録されないこと
・setDeviceTokenを呼び出す => 登録されること
