### PR TITLE
Fix #43 installation.deleteした後、setDeviceTokenを2回呼び出さないと登録されない

### DIFF
--- a/src/android/NiftyPushPlugin.java
+++ b/src/android/NiftyPushPlugin.java
@@ -269,6 +269,9 @@ public class NiftyPushPlugin extends CordovaPlugin
                             // Check duplicated registration ID.
                             if (NCMBException.DUPLICATE_VALUE.equals(saveErr.getCode())) {
                                 updateInstallation(installation, callbackContext);
+                            } else if (NCMBException.DATA_NOT_FOUND.equals(saveErr.getCode())) {
+                                // Retry
+                                setDeviceToken(args, callbackContext);
                             } else {
                                 saveErr.printStackTrace();
                                 callbackContext.error(getErrorJson(saveErr.getCode(), "Failed to save registration ID."));


### PR DESCRIPTION
## 概要(Summary)

- Fixed #43

## 動作確認手順(Step for Confirmation)

・setDeviceTokenしてNCMBのinstallationに登録する
・コンパネでinstallationを削除する
・setDeviceTokenを1回呼び出す => 登録されること
